### PR TITLE
302 redirect breaks installer download

### DIFF
--- a/lib/pngcrush-installer.js
+++ b/lib/pngcrush-installer.js
@@ -19,6 +19,7 @@
     fs = require( 'fs' ),
     mkdirp = require( 'mkdirp' ),
     RSVP = require( './rsvp' ),
+    installerFilename = '',
     execFile = require( "child_process" ).execFile;
 
   var expand = function( filepath , isWin ){
@@ -26,6 +27,7 @@
     if( isWin ){
       p.resolve();
     } else {
+      console.log('Extracting '+installerFilename+'…');
       execFile( "tar" , ["-xzvf", filepath ], function( err, stdout, stderr ){
         if( err ){
           p.reject( err );
@@ -48,34 +50,80 @@
   };
 
   exports.getFileURL = function( isWin , isWin64 ){
-    var url;
-    if( !!isWin && !!isWin64 ){
-      url = "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.7.66/pngcrush_1_7_66_w64.exe";
-    } else if( !!isWin ) {
+    var url, urlArr;
+
+    if( !!isWin ) {
       url = "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.7.66/pngcrush_1_7_66_w32.exe";
+      if( !!isWin64 ){
+        url = "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.7.66/pngcrush_1_7_66_w64.exe";
+      }
     } else {
       url = "http://downloads.sourceforge.net/project/pmt/pngcrush/1.7.66/pngcrush-1.7.66.tar.gz";
     }
+
+    urlArr = url.split( "/" );
+    installerFilename = urlArr[ urlArr.length - 1 ];
+
     return url;
   };
 
+
+
   exports.downloadAndSave = function( url ){
     var promise = new RSVP.Promise();
-    var urlArr = url.split( "/" );
-    var filename = urlArr[ urlArr.length - 1 ];
-    var dest = path.resolve( path.join( __dirname , '..' , filename ) );
+    var dest = path.resolve( path.join( __dirname , '..' , installerFilename ) );
+    var maxRedirects = 3; // Capped at 3. Should be adequate.
+    var redirectCount = 0;
     var file = fs.createWriteStream( dest );
 
-    http.get( url, function( response ) {
-      var r = response.pipe( file );
-      r.on( 'close' , function(){
-        console.log( "File downloaded to: " + dest );
-        promise.resolve( dest );
-      });
-      file.on( 'error' , function( err ){
-        promise.reject( err );
-      });
+    file.on('open',function(fd){
+      var getDownload = function(url){
+        console.log('GET: ' +url)
+        http.get(url,function(response){
+          console.log('Status: '+response.statusCode);
+
+          if( response.statusCode === 302 && maxRedirects > redirectCount ){
+            redirectCount++;
+            console.log('\nRedirecting…\n');
+            return getDownload(response.headers.location);
+          } else {
+            console.log('\nDownloading '+installerFilename+'…');
+          }
+
+          var r = response.pipe( file );
+
+          r.on( 'close' , function() {
+            console.log('Download complete!\n');
+
+            var destRelative = dest;
+            if(~dest.indexOf('/node_modules/')){
+              destRelative = "./node_modules/"+dest.split('/node_modules/')[1];
+            }
+
+            // Test the validity of the downloaded archive
+            // TODO: Check for gunzip (?)
+            execFile( "gunzip", ["-t", dest], function(err, stdout, stderr){
+              if( err || stderr ){
+                console.log( ''+installerFilename+' is not a valid tar archive.' );
+                promise.reject(err);
+              } else {
+                promise.resolve( dest );
+              }
+            });
+          });
+        }).on( 'error' , function( err ){
+          console.log('Request error');
+          promise.reject( err );
+        });
+      }
+
+      getDownload(url);
+
+    }).on( 'error' , function( err ){
+      console.log('File error');
+      promise.reject( err );
     });
+
     return promise;
   };
 
@@ -93,6 +141,7 @@
     expand( filepath , isWin )
     .then( function(){
       if( isWin ){
+        console.log('Installing '+foldername+'…');
         var file = "pngcrush_1_7_66_w32.exe";
         if( isWin64 ){
           file = "pngcrush_1_7_66_w64.exe";
@@ -103,6 +152,7 @@
           dest: path.resolve( path.join( __dirname , '..',  "bin", "pngcrush.exe" ))
         });
       } else {
+        console.log('Building '+foldername+'…');
         execFile( "make" , [ "-C", path.resolve( foldername ) ], function( err, stdout, stderr ){
           if( err ){
             p.reject( err );
@@ -112,6 +162,7 @@
             destFolder: path.resolve( path.join( __dirname , '..', "bin" )),
             dest: path.resolve( path.join( __dirname , '..',  "bin", "pngcrush" ))
           });
+          console.log('Success!\n');
         });
       }
     });


### PR DESCRIPTION
The originally referenced mirror is down, and SourceForge is issuing two redirects to a functioning mirror, but `exports.downloadAndSave` is choking on the redirect.
