### PR TITLE
Fix windows pngcrush_*.exe version number

### DIFF
--- a/lib/pngcrush-installer.js
+++ b/lib/pngcrush-installer.js
@@ -150,9 +150,9 @@
     .then( function(){
       if( isWin ){
         console.log('Installing '+foldername+'...');
-        var file = "pngcrush_1_7_66_w32.exe";
+        var file = "pngcrush_1_7_67_w32.exe";
         if( isWin64 ){
-          file = "pngcrush_1_7_66_w64.exe";
+          file = "pngcrush_1_7_67_w64.exe";
         }
         p.resolve({
           file: path.resolve( path.join( __dirname, '..', file )),


### PR DESCRIPTION
Without this, installer fails to copy pngcrush.exe under /bin on windows platform.
